### PR TITLE
Fix Travis permission issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,5 @@
 language: node_js
 node_js:
-    8.0
-env:
-    CXX=g++-4.8
-cache:
-  directories:
-    "node_modules"
-addons:
-  apt:
-    sources:
-      ubuntu-toolchain-r-test
-    packages:
-      g++-4.8
-install:
-    - npm install
-script:
-    - npm run build
+  8.0
+before_script:
+  - chmod +x dist/index.js

--- a/src/index.js
+++ b/src/index.js
@@ -17,9 +17,9 @@ yargs
   .argv;
 
 function initNewProject(name) {
-  console.log(`Initializing new project ${name}...`);
+  console.log(`Initializing ${name} project...`);
   downloadRepo(UNDERPANTS_REPOSITORY, { target: name })
     .then(() => {
-      console.log('Done! Now put your clothes.');
+      console.log('Done! Now put your clothes on.');
     });
 }


### PR DESCRIPTION
I don't know if this will work, but it might.

This PR basically reverts all your tests, except for some wording corrections you made and the cleanup for the `travis.yml` file.

Putting that aside, what's the deal then? `before_script` it's supposed to run before tests. I'm attempting to give permissions to the file that needs permissions. I think we should try it.